### PR TITLE
Fix typo in argument name

### DIFF
--- a/workflows-samples/export-to-bigquery/export-to-bigquery-delete-batch-jobs.yaml
+++ b/workflows-samples/export-to-bigquery/export-to-bigquery-delete-batch-jobs.yaml
@@ -6,7 +6,7 @@ main:
       - project: ${default(map.get(args, "project"), sys.get_env("GOOGLE_CLOUD_PROJECT_ID"))}
       - location: ${default(map.get(args, "location"), sys.get_env("GOOGLE_CLOUD_LOCATION"))}
       - job_filter: ${default(map.get(args, "job_filter"), "(status.state:SUCCEEDED OR status.state:FAILED) AND create_time<=\"2023-05-01T00:00:00Z\"")}
-      - page_size: ${default(map.get(args, "pige_size"), 100)} # default page size to 100
+      - page_size: ${default(map.get(args, "page_size"), 100)} # default page size to 100
       - dataset_id: ${default(map.get(args, "dataset_id"), "default_dataset_id")} # default dataset_id as default_dataset_id
       - table_id: ${default(map.get(args, "table_id"), "default_table_id")} # default table id as default_table_id
   - init:


### PR DESCRIPTION
This PR fixes a typo in the export-to-bigquery-delete-batch-jobs.yaml workflow so that users can change the page size with a "page_size" argument instead of "pige_size."

The default of 100 prevented this typo from causing failure.

Thank you for making this script! It's fixing our latency issue with the Batch Job List page which is very appreciated.