### PR TITLE
Fixes to transcode.sh to enable Google Batch tutorial to work

### DIFF
--- a/transcoding/transcode.sh
+++ b/transcoding/transcode.sh
@@ -13,14 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y update
+DEBIAN_FRONTEND=noninteractive sudo apt-get -y install ffmpeg
 
-sudo apt-get -y update
-sudo apt-get -y install ffmpeg
-
-dir=/mnt/share
+dir=/mnt/disks/share
 infile=$dir/input/video-$BATCH_TASK_INDEX.mp4
 outfile=$dir/output/video-$BATCH_TASK_INDEX.webm
-vopts=-c:v libvpx-vp9 -b:v 1800k -minrate 1500 -maxrate 1610
+vopts="-c:v libvpx-vp9 -b:v 1800k -minrate 1500 -maxrate 1610"
 
 mkdir -p $dir/output
 ffmpeg -i $infile $vopts -an $outfile


### PR DESCRIPTION
Out of the box, the Google Batch Quick-Start tutorial provided on the Google Cloud Console didn't work. I had to fix some bugs to enable the job submission to work cleanly. Below is a summary of my changes:

- Added DEBIAN_FRONTEND to suppress interaction requests from `apt-get`
- Fixed `dir` to match the path in the `jobs.json` file
- Quoted the definition of `vopts` so that there won't be an error when the shell looks for the `libvpx-vp9` command.