### PR TITLE
fix: remove spurious 'install' package name from pip command

### DIFF
--- a/train-cnn/Container/Dockerfile
+++ b/train-cnn/Container/Dockerfile
@@ -5,4 +5,4 @@ COPY scripts /scripts
 
 # Install various dependencies
 RUN yum install -y python3-pip libcudnn8 unzip
-RUN pip3 install install torchvision pillow
+RUN pip3 install torchvision pillow


### PR DESCRIPTION
The GPU training Dockerfile contains a duplicated `install` keyword that pip interprets as a package name:

```dockerfile
RUN pip3 install install torchvision pillow
```

`install` is not registered on PyPI. An attacker who registers the name at any version will have their package fetched and executed during container build — as root, inside an NVIDIA CUDA environment with access to build credentials and any service account tokens available to the Docker daemon.

This PR removes the extraneous `install` argument, correcting the command to:

```dockerfile
RUN pip3 install torchvision pillow
```
